### PR TITLE
Update neomodel to 4.0.3

### DIFF
--- a/docker/docker-compose-tests.yml
+++ b/docker/docker-compose-tests.yml
@@ -12,8 +12,14 @@ services:
     environment:
       NEO4J_BOLT_URL: bolt://neo4j:neo4j@neo4j:7687
   neo4j:
-    image: neo4j:3.3-enterprise
+    image: neo4j:3.5.26
     environment:
+      NEO4J_apoc_export_file_enabled: "true"
+      NEO4J_apoc_import_file_enabled: "true"
+      NEO4J_apoc_import_file_use__neo4j__config: "true"
+      NEO4JLABS_PLUGINS: "[\"apoc\"]"
       NEO4J_AUTH: none
       NEO4J_dbms_security_procedures_unrestricted: apoc.*
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
+      NEO4J_dbms_connector_bolt_enabled: "true"
+      NEO4J_dbms_connector_bolt_listen__address: "0.0.0.0:7687"

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -117,7 +117,7 @@ docutils==0.16 \
     #   sphinx
     #   sphinx-rtd-theme
 https://github.com/release-engineering/estuary-api/tarball/master#egg=estuary \
-    --hash=sha256:97c13baa398305ddb87d03ed5d05d0039dd6872e82798e3fadefce69bac6bd44
+    --hash=sha256:42ee37438819e012b49c380d5f7d2476848d82a8c9a1540deda384f5b96e04b5
     # via estuary-updater (setup.py)
 fedmsg[commands,consumers]==1.1.2 \
     --hash=sha256:bddb68b536b9c6d95025ac1fefdd2f50f77247b2de416b0988363c86f5867c20
@@ -254,20 +254,17 @@ moksha.hub==1.5.17 \
     # via
     #   estuary-updater (setup.py)
     #   fedmsg
-neo4j-driver==1.7.2 \
-    --hash=sha256:7138899da14f6b0042e3a0097441a96e6a8f0303de5d1e0cd08551caa2455543
+neo4j-driver==4.1.1 \
+    --hash=sha256:21fa285a9d3bbb9dd50d9d9b379376a42fac2ed0706d58520ec36c6afd12f252
     # via neomodel
 neobolt==1.7.17 \
     --hash=sha256:1d0d5efce7221fc4f0ffc4a315bc5272708be5aa2aef5434269e800372d8db89
-    # via neo4j-driver
-neomodel==3.3.2 \
-    --hash=sha256:1fb666e46ada72bc0f5ac9e6adf4271aa669e9757eb1f14a586f1cd224e5a8c1
+    # via neomodel
+neomodel==4.0.3 \
+    --hash=sha256:e8e182ee5c5089631aec5aa920fc8db8de8241302a48bf3463c86daf68b87212
     # via
     #   estuary
     #   estuary-updater (setup.py)
-neotime==1.7.4 \
-    --hash=sha256:4e0477ba0f24e004de2fa79a3236de2bd941f20de0b5db8d976c52a86d7363eb
-    # via neo4j-driver
 oauth2client==4.1.3 \
     --hash=sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac \
     --hash=sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6
@@ -358,8 +355,8 @@ pytz==2021.1 \
     #   babel
     #   estuary
     #   moksha.common
+    #   neo4j-driver
     #   neomodel
-    #   neotime
 pyzmq==22.0.3 \
     --hash=sha256:13465c1ff969cab328bc92f7015ce3843f6e35f8871ad79d236e4fbc85dbe4cb \
     --hash=sha256:23a74de4b43c05c3044aeba0d1f3970def8f916151a712a3ac1e5cd9c0bc2902 \
@@ -422,6 +419,31 @@ rsa==4.7.2 \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9
     # via oauth2client
+shapely==1.7.1 \
+    --hash=sha256:052eb5b9ba756808a7825e8a8020fb146ec489dd5c919e7d139014775411e688 \
+    --hash=sha256:1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129 \
+    --hash=sha256:17df66e87d0fe0193910aeaa938c99f0b04f67b430edb8adae01e7be557b141b \
+    --hash=sha256:182716ffb500d114b5d1b75d7fd9d14b7d3414cef3c38c0490534cc9ce20981a \
+    --hash=sha256:2df5260d0f2983309776cb41bfa85c464ec07018d88c0ecfca23d40bfadae2f1 \
+    --hash=sha256:35be1c5d869966569d3dfd4ec31832d7c780e9df760e1fe52131105685941891 \
+    --hash=sha256:46da0ea527da9cf9503e66c18bab6981c5556859e518fe71578b47126e54ca93 \
+    --hash=sha256:4c10f317e379cc404f8fc510cd9982d5d3e7ba13a9cfd39aa251d894c6366798 \
+    --hash=sha256:4f3c59f6dbf86a9fc293546de492f5e07344e045f9333f3a753f2dda903c45d1 \
+    --hash=sha256:60e5b2282619249dbe8dc5266d781cc7d7fb1b27fa49f8241f2167672ad26719 \
+    --hash=sha256:617bf046a6861d7c6b44d2d9cb9e2311548638e684c2cd071d8945f24a926263 \
+    --hash=sha256:6593026cd3f5daaea12bcc51ae5c979318070fefee210e7990cb8ac2364e79a1 \
+    --hash=sha256:6871acba8fbe744efa4f9f34e726d070bfbf9bffb356a8f6d64557846324232b \
+    --hash=sha256:791477edb422692e7dc351c5ed6530eb0e949a31b45569946619a0d9cd5f53cb \
+    --hash=sha256:8e7659dd994792a0aad8fb80439f59055a21163e236faf2f9823beb63a380e19 \
+    --hash=sha256:8f15b6ce67dcc05b61f19c689b60f3fe58550ba994290ff8332f711f5aaa9840 \
+    --hash=sha256:90a3e2ae0d6d7d50ff2370ba168fbd416a53e7d8448410758c5d6a5920646c1d \
+    --hash=sha256:a3774516c8a83abfd1ddffb8b6ec1b0935d7fe6ea0ff5c31a18bfdae567b4eba \
+    --hash=sha256:a5c3a50d823c192f32615a2a6920e8c046b09e07a58eba220407335a9cd2e8ea \
+    --hash=sha256:b40cc7bb089ae4aa9ddba1db900b4cd1bce3925d2a4b5837b639e49de054784f \
+    --hash=sha256:da38ed3d65b8091447dc3717e5218cc336d20303b77b0634b261bc5c1aa2bae8 \
+    --hash=sha256:de618e67b64a51a0768d26a9963ecd7d338a2cf6e9e7582d2385f88ad005b3d1 \
+    --hash=sha256:e3afccf0437edc108eef1e2bb9cc4c7073e7705924eb4cd0bf7715cd1ef0ce1b
+    # via neomodel
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
@@ -432,7 +454,6 @@ six==1.15.0 \
     #   flask-oidc
     #   koji
     #   moksha.common
-    #   neotime
     #   oauth2client
     #   pyopenssl
     #   python-dateutil

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -142,7 +142,7 @@ gssapi==1.6.12 \
     --hash=sha256:c2ec22c0d5719e44d4aaabe0e9641b590f9d235e248df902b5517571622ad278
     # via requests-gssapi
 gunicorn==20.1.0 \
-    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
+    --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e
     # via estuary
 httplib2==0.19.1 \
     --hash=sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d \

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,7 @@ decorator==5.0.7 \
     #   gssapi
     #   moksha.common
 https://github.com/release-engineering/estuary-api/tarball/master#egg=estuary \
-    --hash=sha256:97c13baa398305ddb87d03ed5d05d0039dd6872e82798e3fadefce69bac6bd44
+    --hash=sha256:42ee37438819e012b49c380d5f7d2476848d82a8c9a1540deda384f5b96e04b5
     # via estuary-updater (setup.py)
 fedmsg[commands,consumers]==1.1.2 \
     --hash=sha256:bddb68b536b9c6d95025ac1fefdd2f50f77247b2de416b0988363c86f5867c20
@@ -229,20 +229,17 @@ moksha.hub==1.5.17 \
     # via
     #   estuary-updater (setup.py)
     #   fedmsg
-neo4j-driver==1.7.2 \
-    --hash=sha256:7138899da14f6b0042e3a0097441a96e6a8f0303de5d1e0cd08551caa2455543
+neo4j-driver==4.1.1 \
+    --hash=sha256:21fa285a9d3bbb9dd50d9d9b379376a42fac2ed0706d58520ec36c6afd12f252
     # via neomodel
 neobolt==1.7.17 \
     --hash=sha256:1d0d5efce7221fc4f0ffc4a315bc5272708be5aa2aef5434269e800372d8db89
-    # via neo4j-driver
-neomodel==3.3.2 \
-    --hash=sha256:1fb666e46ada72bc0f5ac9e6adf4271aa669e9757eb1f14a586f1cd224e5a8c1
+    # via neomodel
+neomodel==4.0.3 \
+    --hash=sha256:e8e182ee5c5089631aec5aa920fc8db8de8241302a48bf3463c86daf68b87212
     # via
     #   estuary
     #   estuary-updater (setup.py)
-neotime==1.7.4 \
-    --hash=sha256:4e0477ba0f24e004de2fa79a3236de2bd941f20de0b5db8d976c52a86d7363eb
-    # via neo4j-driver
 oauth2client==4.1.3 \
     --hash=sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac \
     --hash=sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6
@@ -324,8 +321,8 @@ pytz==2021.1 \
     # via
     #   estuary
     #   moksha.common
+    #   neo4j-driver
     #   neomodel
-    #   neotime
 pyzmq==22.0.3 \
     --hash=sha256:13465c1ff969cab328bc92f7015ce3843f6e35f8871ad79d236e4fbc85dbe4cb \
     --hash=sha256:23a74de4b43c05c3044aeba0d1f3970def8f916151a712a3ac1e5cd9c0bc2902 \
@@ -383,6 +380,31 @@ rsa==4.7.2 \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9
     # via oauth2client
+shapely==1.7.1 \
+    --hash=sha256:052eb5b9ba756808a7825e8a8020fb146ec489dd5c919e7d139014775411e688 \
+    --hash=sha256:1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129 \
+    --hash=sha256:17df66e87d0fe0193910aeaa938c99f0b04f67b430edb8adae01e7be557b141b \
+    --hash=sha256:182716ffb500d114b5d1b75d7fd9d14b7d3414cef3c38c0490534cc9ce20981a \
+    --hash=sha256:2df5260d0f2983309776cb41bfa85c464ec07018d88c0ecfca23d40bfadae2f1 \
+    --hash=sha256:35be1c5d869966569d3dfd4ec31832d7c780e9df760e1fe52131105685941891 \
+    --hash=sha256:46da0ea527da9cf9503e66c18bab6981c5556859e518fe71578b47126e54ca93 \
+    --hash=sha256:4c10f317e379cc404f8fc510cd9982d5d3e7ba13a9cfd39aa251d894c6366798 \
+    --hash=sha256:4f3c59f6dbf86a9fc293546de492f5e07344e045f9333f3a753f2dda903c45d1 \
+    --hash=sha256:60e5b2282619249dbe8dc5266d781cc7d7fb1b27fa49f8241f2167672ad26719 \
+    --hash=sha256:617bf046a6861d7c6b44d2d9cb9e2311548638e684c2cd071d8945f24a926263 \
+    --hash=sha256:6593026cd3f5daaea12bcc51ae5c979318070fefee210e7990cb8ac2364e79a1 \
+    --hash=sha256:6871acba8fbe744efa4f9f34e726d070bfbf9bffb356a8f6d64557846324232b \
+    --hash=sha256:791477edb422692e7dc351c5ed6530eb0e949a31b45569946619a0d9cd5f53cb \
+    --hash=sha256:8e7659dd994792a0aad8fb80439f59055a21163e236faf2f9823beb63a380e19 \
+    --hash=sha256:8f15b6ce67dcc05b61f19c689b60f3fe58550ba994290ff8332f711f5aaa9840 \
+    --hash=sha256:90a3e2ae0d6d7d50ff2370ba168fbd416a53e7d8448410758c5d6a5920646c1d \
+    --hash=sha256:a3774516c8a83abfd1ddffb8b6ec1b0935d7fe6ea0ff5c31a18bfdae567b4eba \
+    --hash=sha256:a5c3a50d823c192f32615a2a6920e8c046b09e07a58eba220407335a9cd2e8ea \
+    --hash=sha256:b40cc7bb089ae4aa9ddba1db900b4cd1bce3925d2a4b5837b639e49de054784f \
+    --hash=sha256:da38ed3d65b8091447dc3717e5218cc336d20303b77b0634b261bc5c1aa2bae8 \
+    --hash=sha256:de618e67b64a51a0768d26a9963ecd7d338a2cf6e9e7582d2385f88ad005b3d1 \
+    --hash=sha256:e3afccf0437edc108eef1e2bb9cc4c7073e7705924eb4cd0bf7715cd1ef0ce1b
+    # via neomodel
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
@@ -393,7 +415,6 @@ six==1.15.0 \
     #   flask-oidc
     #   koji
     #   moksha.common
-    #   neotime
     #   oauth2client
     #   pyopenssl
     #   python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ gssapi==1.6.12 \
     --hash=sha256:c2ec22c0d5719e44d4aaabe0e9641b590f9d235e248df902b5517571622ad278
     # via requests-gssapi
 gunicorn==20.1.0 \
-    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
+    --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e
     # via estuary
 httplib2==0.19.1 \
     --hash=sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d \

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,7 @@ setup(
         'moksha.hub',
         'PyOpenSSL',
         'stomper',
-        # Pin the version until this is merged:
-        # https://github.com/neo4j-contrib/neomodel/pull/553
-        'neomodel==3.3.2',
+        'neomodel>=4.0.3',
     ],
     entry_points="""
     [moksha.consumer]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -153,7 +153,7 @@ decorator==5.0.7 \
     #   gssapi
     #   moksha.common
 https://github.com/release-engineering/estuary-api/tarball/master#egg=estuary \
-    --hash=sha256:97c13baa398305ddb87d03ed5d05d0039dd6872e82798e3fadefce69bac6bd44
+    --hash=sha256:42ee37438819e012b49c380d5f7d2476848d82a8c9a1540deda384f5b96e04b5
     # via estuary-updater (setup.py)
 fedmsg[commands,consumers]==1.1.2 \
     --hash=sha256:bddb68b536b9c6d95025ac1fefdd2f50f77247b2de416b0988363c86f5867c20
@@ -314,20 +314,17 @@ moksha.hub==1.5.17 \
     # via
     #   estuary-updater (setup.py)
     #   fedmsg
-neo4j-driver==1.7.2 \
-    --hash=sha256:7138899da14f6b0042e3a0097441a96e6a8f0303de5d1e0cd08551caa2455543
+neo4j-driver==4.1.1 \
+    --hash=sha256:21fa285a9d3bbb9dd50d9d9b379376a42fac2ed0706d58520ec36c6afd12f252
     # via neomodel
 neobolt==1.7.17 \
     --hash=sha256:1d0d5efce7221fc4f0ffc4a315bc5272708be5aa2aef5434269e800372d8db89
-    # via neo4j-driver
-neomodel==3.3.2 \
-    --hash=sha256:1fb666e46ada72bc0f5ac9e6adf4271aa669e9757eb1f14a586f1cd224e5a8c1
+    # via neomodel
+neomodel==4.0.3 \
+    --hash=sha256:e8e182ee5c5089631aec5aa920fc8db8de8241302a48bf3463c86daf68b87212
     # via
     #   estuary
     #   estuary-updater (setup.py)
-neotime==1.7.4 \
-    --hash=sha256:4e0477ba0f24e004de2fa79a3236de2bd941f20de0b5db8d976c52a86d7363eb
-    # via neo4j-driver
 oauth2client==4.1.3 \
     --hash=sha256:b8a81cc5d60e2d364f0b1b98f958dbd472887acaf1a5b05e21c28c31a2d6d3ac \
     --hash=sha256:d486741e451287f69568a4d26d70d9acd73a2bbfa275746c535b4209891cccc6
@@ -446,8 +443,8 @@ pytz==2021.1 \
     #   -r test-requirements.in
     #   estuary
     #   moksha.common
+    #   neo4j-driver
     #   neomodel
-    #   neotime
 pyzmq==22.0.3 \
     --hash=sha256:13465c1ff969cab328bc92f7015ce3843f6e35f8871ad79d236e4fbc85dbe4cb \
     --hash=sha256:23a74de4b43c05c3044aeba0d1f3970def8f916151a712a3ac1e5cd9c0bc2902 \
@@ -505,6 +502,31 @@ rsa==4.7.2 \
     --hash=sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2 \
     --hash=sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9
     # via oauth2client
+shapely==1.7.1 \
+    --hash=sha256:052eb5b9ba756808a7825e8a8020fb146ec489dd5c919e7d139014775411e688 \
+    --hash=sha256:1641724c1055459a7e2b8bbe47ba25bdc89554582e62aec23cb3f3ca25f9b129 \
+    --hash=sha256:17df66e87d0fe0193910aeaa938c99f0b04f67b430edb8adae01e7be557b141b \
+    --hash=sha256:182716ffb500d114b5d1b75d7fd9d14b7d3414cef3c38c0490534cc9ce20981a \
+    --hash=sha256:2df5260d0f2983309776cb41bfa85c464ec07018d88c0ecfca23d40bfadae2f1 \
+    --hash=sha256:35be1c5d869966569d3dfd4ec31832d7c780e9df760e1fe52131105685941891 \
+    --hash=sha256:46da0ea527da9cf9503e66c18bab6981c5556859e518fe71578b47126e54ca93 \
+    --hash=sha256:4c10f317e379cc404f8fc510cd9982d5d3e7ba13a9cfd39aa251d894c6366798 \
+    --hash=sha256:4f3c59f6dbf86a9fc293546de492f5e07344e045f9333f3a753f2dda903c45d1 \
+    --hash=sha256:60e5b2282619249dbe8dc5266d781cc7d7fb1b27fa49f8241f2167672ad26719 \
+    --hash=sha256:617bf046a6861d7c6b44d2d9cb9e2311548638e684c2cd071d8945f24a926263 \
+    --hash=sha256:6593026cd3f5daaea12bcc51ae5c979318070fefee210e7990cb8ac2364e79a1 \
+    --hash=sha256:6871acba8fbe744efa4f9f34e726d070bfbf9bffb356a8f6d64557846324232b \
+    --hash=sha256:791477edb422692e7dc351c5ed6530eb0e949a31b45569946619a0d9cd5f53cb \
+    --hash=sha256:8e7659dd994792a0aad8fb80439f59055a21163e236faf2f9823beb63a380e19 \
+    --hash=sha256:8f15b6ce67dcc05b61f19c689b60f3fe58550ba994290ff8332f711f5aaa9840 \
+    --hash=sha256:90a3e2ae0d6d7d50ff2370ba168fbd416a53e7d8448410758c5d6a5920646c1d \
+    --hash=sha256:a3774516c8a83abfd1ddffb8b6ec1b0935d7fe6ea0ff5c31a18bfdae567b4eba \
+    --hash=sha256:a5c3a50d823c192f32615a2a6920e8c046b09e07a58eba220407335a9cd2e8ea \
+    --hash=sha256:b40cc7bb089ae4aa9ddba1db900b4cd1bce3925d2a4b5837b639e49de054784f \
+    --hash=sha256:da38ed3d65b8091447dc3717e5218cc336d20303b77b0634b261bc5c1aa2bae8 \
+    --hash=sha256:de618e67b64a51a0768d26a9963ecd7d338a2cf6e9e7582d2385f88ad005b3d1 \
+    --hash=sha256:e3afccf0437edc108eef1e2bb9cc4c7073e7705924eb4cd0bf7715cd1ef0ce1b
+    # via neomodel
 six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
@@ -515,7 +537,6 @@ six==1.15.0 \
     #   flask-oidc
     #   koji
     #   moksha.common
-    #   neotime
     #   oauth2client
     #   pyopenssl
     #   python-dateutil

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -188,7 +188,7 @@ gssapi==1.6.12 \
     --hash=sha256:c2ec22c0d5719e44d4aaabe0e9641b590f9d235e248df902b5517571622ad278
     # via requests-gssapi
 gunicorn==20.1.0 \
-    --hash=sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8
+    --hash=sha256:9dcc4547dbb1cb284accfb15ab5667a0e5d1881cc443e0677b4882a4067a807e
     # via estuary
 httplib2==0.19.1 \
     --hash=sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d \


### PR DESCRIPTION
Now that the following PR has been released,
neomodel can be updated to the latest release:
https://github.com/neo4j-contrib/neomodel/pull/553

This is a follow-up from https://github.com/redhat-exd-rebuilds/estuary-api/pull/305.