### PR TITLE
Including URL CA list - CWFHEALTH-1947

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -e
 
-if [ -n "${CA_URL}" ] && [ ! -f "/tmp/.imported" ]; then
+if [ -n "${CA_URLS}" ] && [ ! -f "/tmp/.imported" ]; then
+    URLS=($(echo "${CA_URLS}" | tr ',' '\n'))
     # Since update-ca-trust doesn't work as a non-root user, let's just append to the bundle directly
-    curl -k --silent --show-error "${CA_URL}" >> /etc/pki/tls/certs/ca-bundle.crt
+    for url in "${URLS[@]}"; do
+        curl -k --silent --show-error "$url" >> /etc/pki/tls/certs/ca-bundle.crt
+    done
     # Create a file so we know not to import it again if the container is restarted
     touch /tmp/.imported
 fi


### PR DESCRIPTION
Adding a new way to create the bundle certificate file to include new CA root. The old can't be excluded because is still valid (till 2024). To implement this there is a new var CA_URLS, that is a list of root certificates separated by comma that afterwards will be added to a file